### PR TITLE
Skip deploy job if not on master branch

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -57,6 +57,7 @@ jobs:
         if-no-files-found: error
 
   deploy:
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -64,6 +65,5 @@ jobs:
     needs: build
     steps:
       - name: Deploy to GitHub Pages
-        if: github.ref_name == env.BRANCH_TO_DEPLOY
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
Prevents confusing behaviour in github actions that PR fails,
because no deployment runs.